### PR TITLE
Fixed the glitched UI when replacing a district

### DIFF
--- a/interface/planet_view.gui
+++ b/interface/planet_view.gui
@@ -4416,7 +4416,7 @@ guiTypes = {
 					name = "district_constructions_list"
 					position = { x = 15 y = 60 }
 					background = ""
-					size = { x = 250 y = 500 }
+					size = { x = 330 y = 565 }
 					scrollbarType = "standardlistbox_slider"
 					borderSize = { x = 0 y = 0 }
 					orientation = "UPPER_LEFT"
@@ -6015,7 +6015,7 @@ guiTypes = {
 	containerWindowType = {
 		name = "planet_district_construction_entry"
 		position = { x= 0 y= 0 }
-		size = { width = 250 height = 100 }
+		size = { width = 330 height = 185 }
 
 		background = {
 			name = "background"
@@ -6025,12 +6025,13 @@ guiTypes = {
 
 		containerWindowType = {
 			name = "district_icon"
-			size = { width = 77 height = 77	}
-			position = { x = 1 y = 22 }
+			size = { width = 115 height = 115	}
+			position = { x = 0 y = 32 }
 
 			iconType = {
 				name = "district_icon"
 				position = { x = 1  y = 2 }
+				scale = 1.5
 				spriteType = "GFX_district_unknown"
 				alwaysTransparent = yes
 			}
@@ -6044,7 +6045,7 @@ guiTypes = {
 
 		containerWindowType = {
 			name = "district_name"
-			size = { width = 250 height = 22 }
+			size = { width = 330 height = 32 }
 			position = { x = 0 y = 0 }
 
 			background = {
@@ -6057,9 +6058,9 @@ guiTypes = {
 				name = "district_name"
 				font = "cg_16b"
 				text = "District Name"
-				position = { x = 0 y = 3 }
+				position = { x = 36 y = 8 }
 				maxWidth = 250
-				maxHeight = 20
+				maxHeight = 30
 				fixedSize = yes
 				format = center
 				alwaysTransparent = yes
@@ -6070,9 +6071,9 @@ guiTypes = {
 			name = "district_effects"
 			font = "cg_16b"
 			text = "District effects go here"
-			position = { x = 85 y = 25 }
-			maxWidth = 150
-			maxHeight = 80
+			position = { x = 135 y = 35 }
+			maxWidth = 180
+			maxHeight = 100
 			fixedSize = yes
 			format = left
 			alwaysTransparent = yes
@@ -6082,13 +6083,24 @@ guiTypes = {
 			name = "district_cost"
 			font = "cg_16b"
 			text = "50"
-			position = { x = 85 y = 78 }
+			position = { x = 105 y = 155 }
 			maxWidth = 180
 			maxHeight = 80
 			fixedSize = yes
-			format = right
+			format = left
 			alwaysTransparent = yes
 			text_color_code = "Y"
+		}
+		
+		containerWindowType = {
+		    name = "distec_details_tec_shadow_window"
+		    size = { width = 329 height = 40 } #width = 270 height = 301 }
+		    position = { x = 0 y = 146 }
+		    background = {
+		    	position = { x = 0 y = 0 }
+		    	name = "distec_detail_window_background"
+		    	spriteType = "GFX_button_light"
+		    }
 		}
 
 


### PR DESCRIPTION
if you attempt to replace a district in the current version of evolved, you'll see this broken UI:
<img width="277" alt="image" src="https://user-images.githubusercontent.com/31822295/210131707-2916baf7-44cc-4526-9d50-83931ae4ad5e.png">

I took the changes from UI for regular district construction and applied them to the UI for district replacement. Here's what it looks like in this branch:
<img width="276" alt="image" src="https://user-images.githubusercontent.com/31822295/210131690-c0e94a1a-3fab-4453-801b-de0940e1587e.png">

And by the way, the scrollable list of districts in the current version doesn't cover the entire district construction window; this PR fixes that, too. This wasn't visible before because the items in the district list used to be too few and small to reach the end of that window

