### PR TITLE
Disabled cloning techs if cloning buildings are disabled in policies

### DIFF
--- a/common/technology/zz_evolved_soc_tech.txt
+++ b/common/technology/zz_evolved_soc_tech.txt
@@ -957,6 +957,10 @@ tech_tec_cloning_2 = {
 	weight_modifier = {
 		factor = 1.5 	# genetech needs to be a bit more common
 		modifier = {
+			factor = 0
+			has_policy_flag = tec_purity_assembly
+		}
+		modifier = {
 			factor = 1.5
 			is_hive_empire = yes
 		}
@@ -1014,6 +1018,10 @@ tech_tec_cloning_3 = {
 
 	weight_modifier = {
 		factor = 1.5 	# genetech needs to be a bit more common
+		modifier = {
+			factor = 0
+			has_policy_flag = tec_purity_assembly
+		}
 		modifier = {
 			factor = 1.5
 			is_hive_empire = yes


### PR DESCRIPTION
If assembly policy is at 'focus on purity', you can't build the buildings that are unlocked by these techs. Unlike similar techs for bio-constructs and robotic workers, these techs don't provide any benefit other than unlocking the buildings, so they are always useless to empires with focus on purity