### PR TITLE
Buffed aid agency

### DIFF
--- a/common/buildings/zz_evolved_overlord_holdings.txt
+++ b/common/buildings/zz_evolved_overlord_holdings.txt
@@ -310,7 +310,7 @@ holding_aid_agency = {					# Amenities
 	}
 
 	planet_modifier = {
-		monthly_loyalty = 0.5
+		monthly_loyalty = 1.5
 	}
 
 	resources = {


### PR DESCRIPTION
Vanilla aid agency is pretty useless outside of roleplay: it usually doesn't even pay back for the holding limit it requires, and there's no non-roleplay reason to use it instead of the overlord garrison. This change would make the gap between the two holdings a lot smaller