### PR TITLE
Make shattered rings not have unlimited building slots

### DIFF
--- a/common/scripted_triggers/zzz_evolved_scripted_triggers.txt
+++ b/common/scripted_triggers/zzz_evolved_scripted_triggers.txt
@@ -925,7 +925,12 @@
 			tec_is_elysium = yes
 			tec_is_ringworld = yes
 			tec_is_uncapped_planet = yes
-			tec_has_infinite_menial_districts = yes
+			AND = {
+				tec_has_infinite_menial_districts = yes
+				NOT = {
+					uses_district_set = shattered_ring_world
+				}
+			}
 			tec_special_infinite_buildings = yes
 		}
 		]


### PR DESCRIPTION
Shattered ring segments have more building slots than the main ring segment, which doesn't seem right. That can be fixed by either adding structural damage blockers to the shattered segments or making the shattered segments not have unlimited building slots. Unlike the main segment, shattered segments use city districts that increase the number of buildings, so the second option seems reasonable to me