### PR TITLE
Removes redundant "automate [district]" from Machine Intelligence, loosens restrictions for Nexus swaps 

### DIFF
--- a/common/decisions/zz_evolved_mechanic_decisions.txt
+++ b/common/decisions/zz_evolved_mechanic_decisions.txt
@@ -1239,7 +1239,6 @@ decision_tec_machine_extraction_capital = {
 		}
 		# Not has extraction capital
 		tec_has_machine_extraction_capital = no
-		# Regular planets only
 		tec_allows_machine_alt_capitals = yes
 	}
 
@@ -1295,7 +1294,6 @@ decision_tec_machine_production_capital = {
 		}
 		# Not has extraction capital
 		tec_has_machine_production_capital = no
-		# Regular planets only
 		tec_allows_machine_alt_capitals = yes
 	}
 
@@ -1354,8 +1352,7 @@ decision_tec_machine_normal_capital = {
 			tec_has_machine_extraction_capital = yes
 			tec_has_machine_production_capital = yes
 		}
-		# Regular planets only
-		uses_district_set = standard
+		tec_allows_machine_alt_capitals = yes
 	}
 
 	effect = {

--- a/common/decisions/zz_evolved_origin_decisions.txt
+++ b/common/decisions/zz_evolved_origin_decisions.txt
@@ -379,6 +379,12 @@ decision_tec_automation_on = {
 			uses_district_set = hive_world
 		}
 		has_planet_flag = tec_automation_mechanic_off
+		owner = {
+			NOT = {
+			#Machines have their own version of automation VIA nexus capital swaps
+				has_authority = auth_machine_intelligence
+			}
+		}
 	}
 
 	effect = {
@@ -477,6 +483,10 @@ decision_tec_automation_off = {
 		owner = {
 			is_ai = no
 			tec_is_automated_empire = yes
+			NOT = {
+			#Machines have their own version of automation VIA nexus capital swaps
+				has_authority = auth_machine_intelligence
+			}
 		}
 		NOT = {
 			has_planet_flag = tec_automation_mechanic_off

--- a/common/scripted_triggers/zzz_evolved_buildings_scripted_triggers.txt
+++ b/common/scripted_triggers/zzz_evolved_buildings_scripted_triggers.txt
@@ -1801,10 +1801,11 @@ tec_planet_allows_automation = {
 	}
 }
 
+# Only planets with urban and/or rural districts
 tec_allows_machine_alt_capitals = {
 	OR = {
-		uses_district_set = standard
-		tec_has_rural_mimics = yes
+		tec_has_any_menial_district = yes
+		tec_has_any_urban_district = yes
 	}
 }
 


### PR DESCRIPTION
This bothered me when I was trying out MIs a while ago so I made a personal fix, seeing if upstream Evolved would like this

- Removes the [non functioning for MIs] automation decision from MIs
- Allows production/extractor nexus capitals to be used on a lot more planet types that isn't "basic planet", mostly relevant lore-wise to machine worlds being able to use the unique machine nexus capitals but also any other world type that can benefit from it