### PR TITLE
Fill empty building slots on FE capitals

### DIFF
--- a/common/buildings/zz_evolved_military_buildings.txt
+++ b/common/buildings/zz_evolved_military_buildings.txt
@@ -1207,6 +1207,7 @@ building_planetary_shield_generator = {
 		owner = {
 			is_ai = yes
 			is_at_war = no
+			is_fallen_empire = no
 		}
 	}
 	

--- a/events/zz_evolved_game_start_events.txt
+++ b/events/zz_evolved_game_start_events.txt
@@ -4224,6 +4224,16 @@ country_event = {	# FE adjustments
 			# /
 		# /
 
+		# Capital fortification
+			capital_scope = {
+				add_building = building_planetary_shield_generator
+				while = {
+					count = 5
+					add_building = building_fe_stronghold
+				}
+			}
+		# /
+
 		# Random minor megastructure in capital
 			random_list = {
 				10 = { # Research mega


### PR DESCRIPTION
Players used to be forced to conquer FE worlds using regular troops, which was quite challenging. Nowadays, however, every empire has access to xenomorph armies, and orbital bombardment is a lot more deadly, so conquering those worlds is a mere sidenote. This PR fixes this power creep by introducing heavy fortifications to FE capitals. This also fills the out-of-place-looking empty slots on those worlds
![image](https://github.com/Stellaris-Evolved/stellaris-evolved/assets/31822295/af0b610a-4cd7-4d76-b8ff-1d3a04747c8b)
