### PR TITLE
Add base cg upkeep to operators

### DIFF
--- a/common/pop_jobs/zz_evolved_specialist_jobs.txt
+++ b/common/pop_jobs/zz_evolved_specialist_jobs.txt
@@ -2873,6 +2873,7 @@
 				physics_research = 1
 				society_research = 1
 				engineering_research = 1
+				consumer_goods = 1
 			}
 		}
 


### PR DESCRIPTION
Remeber my wall of text analyzing the efficiency of archivists? The exact same logic applies to operators, except with research and unity swapped. Archivists got cg upkeep after that, so that seems to be the canonical way to make this balanced