### PR TITLE
AI fixes

### DIFF
--- a/common/ai_budget/zze_ow_alloys_budgets.txt
+++ b/common/ai_budget/zze_ow_alloys_budgets.txt
@@ -122,7 +122,7 @@ alloys_expenditure_planets = {
 	}
 
 	desired_min = {
-		base = 100
+		base = 500
 	}
 
 	desired_max = {

--- a/common/ai_budget/zze_ow_minerals_budget.txt
+++ b/common/ai_budget/zze_ow_minerals_budget.txt
@@ -146,3 +146,58 @@ minerals_expenditure_colonies_lithoid_expand = {
 		}
 	}
 }
+
+
+minerals_expenditure_deposit_blockers = {
+	resource = minerals
+	type = expenditure
+	category = deposit_blockers
+
+	potential = {
+		any_owned_planet = {
+			OR = {
+				has_deposit = d_ruined_arcology
+				has_deposit = d_resource_consolidation_1
+				has_deposit = d_tec_machine_rubble_big
+				AND = {
+					OR = {
+						has_deposit = d_buried_lithoids
+						has_deposit = d_hibernating_lithoids
+					}
+					is_homeworld = yes
+				}
+			}
+		}
+	}
+
+	weight = {
+		weight = 0.3
+		modifier = {
+			factor = 5
+
+			# if we have any planet that is currently completely blocked
+			any_owned_planet = {
+				OR = {
+					has_deposit = d_ruined_arcology
+					AND = {
+						OR = {
+							has_deposit = d_buried_lithoids
+							has_deposit = d_hibernating_lithoids
+						}
+						is_homeworld = yes
+					}
+				}
+				num_free_districts = { type = any value < 1 }
+			}
+		}
+	}
+
+	# base remove blocker cost
+	desired_min = {
+		base = 250
+	}
+
+	desired_max = {
+		base = 1500
+	}
+}

--- a/common/inline_scripts/edicts/zzz_ow_vanilla_edicts.txt
+++ b/common/inline_scripts/edicts/zzz_ow_vanilla_edicts.txt
@@ -1,0 +1,33 @@
+research_subsidies = {
+	length = @EdictPerpetual
+	icon = "GFX_edict_type_policy"
+
+	resources = {
+		category = edicts
+		cost = {
+			unity = @Edict3Cost
+			multiplier = value:edict_size_effect
+		}
+		upkeep = {
+			unity = @Edict3Cost
+			multiplier = value:edict_size_effect
+		}
+	}
+
+	modifier = {
+		planet_researchers_produces_mult = 0.10
+		planet_researchers_energy_upkeep_add = 1
+	}
+
+	potential = {
+		has_tradition = tr_discovery_databank_uplinks
+	}
+
+	allow = {
+		is_ai = no
+	}
+
+	ai_weight = {
+		weight = 0
+	}
+}

--- a/common/pop_jobs/zz_ow_04_gestalt_jobs.txt
+++ b/common/pop_jobs/zz_ow_04_gestalt_jobs.txt
@@ -510,7 +510,7 @@ evaluator = {
 	weight = {
 		weight = @synapse_drone_job_weight
 		mult = value:job_weights_modifier|JOB|evaluator|RESOURCE|unity|
-		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
+		#mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 	}
 
 	inline_script = "jobs/automodding_priority_unity"
@@ -570,7 +570,7 @@ synapse_drone = {
 	weight = {
 		weight = @synapse_drone_job_weight
 		mult = value:job_weights_modifier|JOB|synapse_drone|RESOURCE|unity|
-		mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
+		#mult = value:scripted_modifier_job_weight_mult|MODIFIER|pop_job_amenities_mult|
 		modifier = {
 			factor = 1.5
 			has_job = synapse_drone

--- a/common/traits/zz_evolved_robotic_traits.txt
+++ b/common/traits/zz_evolved_robotic_traits.txt
@@ -186,6 +186,7 @@
 			exists = from
 			from = {
 				is_machine_empire = yes
+				is_ai = no
 			}
 		}
 		species_possible_remove = {
@@ -229,6 +230,7 @@
 					is_machine_empire = yes
 					has_country_flag = tec_synth_slow_transition
 				}
+				is_ai = no
 			}
 		}
 		species_possible_remove = {
@@ -280,6 +282,7 @@
 			exists = from
 			from = {
 				is_machine_empire = yes
+				is_ai = no
 			}
 		}
 		species_possible_remove = {


### PR DESCRIPTION
Disallowed Research Subsidies : 
- It was causing tremendous damage to AIs both on lower and higher difficulties (since the upkeep flat is also scaled lol)
Alloy Budget increase : 
- For cosmo and compat with other mods with buildings with alloy costs
Mineral Blocker budget increase : 
- For MEs starting with Resource Consolidation, as they could never clear the last blocker
Disallowed Upkeep switch traits for robot for AI : 
- Caused issues since AI is stupid, and also because they would ALWAYS take these since they cost 0
Idle Maintenance Drone fix : 
- Removed amenities weight from evaluator job and synapse